### PR TITLE
Fix/lexer not detecting negative numbers

### DIFF
--- a/src/number/lexer.test.ts
+++ b/src/number/lexer.test.ts
@@ -51,7 +51,11 @@ describe('Lexer', () => {
     ['12+3', 3],
     ['9*(2-1)', 7],
     ['9*9*9', 5],
-    ['{10+[5+(2+1)]}', 13]
+    ['{10+[5+(2+1)]}', 13],
+    ['-10', 1],
+    ['10 + (-10)', 5],
+    ['-10-10-10', 5],
+    ['+10', 1],
   ])('"%s" input should return %i amount of tokens', (input, expected) => {
     const lexer = new Lexer(input);
 

--- a/src/number/lexer.ts
+++ b/src/number/lexer.ts
@@ -193,15 +193,20 @@ export class Lexer {
     * tokenized as a signed number, not an operation.
     */
   private readTokenType(): string {
-    if (
-      (this.char === '+' || this.char === '-') &&
-      isNumber(this.peekChar()) &&
-      !isNumber(this.lastChar())
-    ) {
+    if (this.isSignedNumber()) {
       return this.readNumber(); // Read as a signed number.
     }
 
     return this.char;
+  }
+
+  /**
+    * isSignedNumber returns true is there are a number just next to a '+' or '-' symbol and the symbol does not have a number before.
+    */
+  private isSignedNumber(): boolean {
+    return (this.char === '+' || this.char === '-') &&
+      isNumber(this.peekChar()) &&
+      !isNumber(this.lastChar());
   }
 
   /**
@@ -250,7 +255,11 @@ export class Lexer {
       value = this.readComparation();
       tokenType = TokenString.get(value);
     } else if (tokenType) {
-      // If is a single character token, like '{', ']' or '+'.
+      // If is a single character token, like '{', ']' or '+'. 
+      if (this.isSignedNumber()) {
+        tokenType = TokenType.Number;
+      }
+
       value = this.readTokenType();
     } else if (isNumber(this.char)) {
       // If is a number literal.


### PR DESCRIPTION
## Changes
 * Now the lexer detects `-` symbols that are just next to a number and that does not have a number just before as part of a negative number.