### PR TITLE
Fix number not adding parenthesis in some cases

### DIFF
--- a/src/number/number.test.ts
+++ b/src/number/number.test.ts
@@ -74,7 +74,21 @@ describe('Number', () => {
       expect(actual).toBe(expected);
     });
 
-    test('compound should return the correct string representation of an expression that needs agroupation signs', () => {
+    test('compound should return the correct string of an expression that starts with a group', () => {
+      const a = 19538;
+      const b = 294105;
+      const c = 78522;
+      const expected = `(${b} - ${c}) * ${a}`;
+
+      // Notice that the entire subtraction is the first number of this number.
+      const actual = numToString(
+        compound(compoundFromValues(b, sub, c), mul, identity(a)), // String representation should automatically add parenthesis here.
+      );
+
+      expect(actual).toBe(expected);
+    });
+
+    test('compound should return the correct string of an expression that ends with a group', () => {
       const a = 19538;
       const b = 294105;
       const c = 78522;
@@ -82,11 +96,11 @@ describe('Number', () => {
 
       // Notice that the entire subtraction is the second number of this number.
       const actual = numToString(
-        compound(identity(a), mul, compoundFromValues(b, sub, c)), // String representation should automatically add parenthesis here.
+        compound(identity(a), mul, compoundFromValues(b, sub, c)) // String representation should automatically add parenthesis here.
       );
 
       expect(actual).toBe(expected);
-    });
+   })
   });
 
   test.for([

--- a/src/number/number.ts
+++ b/src/number/number.ts
@@ -97,10 +97,22 @@ export const identity = (a: number): Number => {
  */
 export const compound = (a: Number, o: Operation, b: Number): Number => [
   () => o[0](get(a), get(b)),
-  () =>
-    b[2] != -1 && b[2] < o[2] // If the second operand is not a simple number, and its priority is less than that of this number then:
-      ? o[1](numToString(a), `(${numToString(b)})`) // Add the necessary parenthesis.
-      : o[1](numToString(a), numToString(b)), // If not just pass the strings as they are.
+  () => {
+    // If `b` is not a simple number and its priority is less than the current one then
+    // add parenthesis around `b`, ex. a = 16, b = 12 + 2, a * b -> a * (b) = a * (12 + 2).
+    if (b[2] !== -1 && b[2] < o[2]) {       
+      return o[1](numToString(a), `(${numToString(b)})`)
+    }
+
+    // If `a` is not a simple number and its priority  is less than the current one then
+    // add parenthesis around `a`, ex. a = 27 + 9, b = 5, a * b -> (a) * b = (27 + 9) * 5.
+    if (a[2] !== -1 && a[2] < o[2]) {
+      return o[1](`(${numToString(a)})`, numToString(b));
+    }
+
+    // If both `a` and `b` are simple numbers or have the same priority just pass as they are. ex a = 16, b 9, a + b = 16 + 9.
+    return o[1](numToString(a), numToString(b));
+  },
   o[2],
 ];
 


### PR DESCRIPTION
## Changes
  * Fix number string not adding parenthesis when `a` it's a compound expression with less priority than `b`, for example now if: `a = 12 + 9`, `b = 7`, `a * b`  then its string value will be `(a) * b` = `(12+9) * 7`.